### PR TITLE
update provisioner name pursuant to LINBIT/linstor-csi#11

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ metadata:
 parameters:
   autoplace: "1"
   storagePool: "thin-lvm"
-provisioner: io.drbd.linstor-csi
+provisioner: linstor.csi.linbit.com
 reclaimPolicy: Delete
 ```
 

--- a/sc.yaml
+++ b/sc.yaml
@@ -7,5 +7,5 @@ metadata:
 parameters:
   autoplace: "1"
   storagePool: "thin-lvm"
-provisioner: io.drbd.linstor-csi
+provisioner: linstor.csi.linbit.com
 reclaimPolicy: Delete


### PR DESCRIPTION
As of linstor-csi v0.5.0 the driver name is `linstor.csi.linbit.com`